### PR TITLE
add terraform modules and examples for GCE, Spanner and Cloud Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,73 @@
+# Compiled files
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Ignore Mac .DS_Store files
+.DS_Store
+
+
+# Directories
+.terraform/
+
+# Ignored vscode files
+.vscode/
+
+
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+# Only exists if Bazel was run
+/bazel-out
+
+# dependencies
+/node_modules
+/developer-documents
+/omegatrade-app/frontend/node_modules/
+/frontend/dist
+/omegatrade-app/frontend/package-lock.json
+/omegatrade-app/backend/package-lock.json
+/omegatrade-app/backend/node_modules
+/backend/nodejs-spanner
+/backend/fakedata.js
+/omegatrade-app/frontend/dist/
+
+
+# profiling files
+chrome-profiler-events.json
+speed-measure-plugin.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+

--- a/examples/cloud-spanner/main.tf
+++ b/examples/cloud-spanner/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+provider "google" {
+  version = "3.51.0" # see https://github.com/terraform-providers/terraform-provider-google/releases
+  project = var.project
+}
+
+resource "random_string" "launch_id" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  suffix = format("%s-%s", "tf", random_string.launch_id.result)
+}
+
+module omegatrade {
+  source      = "../../modules/cloud-spanner"
+  suffix      = local.suffix
+  instance_id = var.spanner_instance_id
+  dbname      = var.spanner_dbname
+  config      = var.spanner_config
+  num_nodes   = var.spanner_nodes
+  labels_var  = var.spanner_labels
+  project     = var.project
+}

--- a/examples/cloud-spanner/terraform.scale.tfvars
+++ b/examples/cloud-spanner/terraform.scale.tfvars
@@ -1,0 +1,6 @@
+spanner_instance_id = "omegatrade-instance"
+spanner_dbname      = "omegatrade-db"
+spanner_config      = "regional-us-west1"
+spanner_nodes       = 2
+spanner_labels      = { env = "test" }
+project             = "[ENTER-GCP-PROJECT-ID]"

--- a/examples/cloud-spanner/terraform.tfvars
+++ b/examples/cloud-spanner/terraform.tfvars
@@ -1,0 +1,6 @@
+spanner_instance_id = "omegatrade-instance"
+spanner_dbname      = "omegatrade-db"
+spanner_config      = "regional-us-west1"
+spanner_nodes       = 1
+spanner_labels      = { env = "test" }
+project             = "[ENTER-GCP-PROJECT-ID]"

--- a/examples/cloud-spanner/variables.tf
+++ b/examples/cloud-spanner/variables.tf
@@ -1,0 +1,30 @@
+variable "spanner_instance_id" {
+  type        = string
+  description = "A unique identifier for the instance, which cannot be changed after the instance is created."
+}
+
+variable "spanner_dbname" {
+  type        = string
+  description = "A unique identifier for the database, which cannot be changed after the instance is created."
+}
+
+variable "spanner_config" {
+  type        = string
+  description = "Cloud Spanner Instance config - Regional / multi-region. For allowed configurations, check: https://cloud.google.com/spanner/docs/instances#available-configurations-regional"
+}
+
+variable "spanner_nodes" {
+  type        = number
+  description = "The number of nodes allocated to this instance."
+}
+
+variable "spanner_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Labels to inject into the spanner instance."
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}

--- a/examples/cloudrun/backend/main.tf
+++ b/examples/cloudrun/backend/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+provider "google" {
+  version = "3.51.0" # see https://github.com/terraform-providers/terraform-provider-google/releases
+  project = var.project
+}
+
+resource "random_string" "launch_id" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  suffix = format("%s-%s", "tf", random_string.launch_id.result)
+}
+
+module "cloud_run_backend" {
+  source               = "../../../modules/cloudrun"
+  suffix               = local.suffix
+  service_name         = "${var.cloud_run_service_name}-backend"
+  container_image_path = var.backend_container_image_path
+  region               = var.cloud_run_region
+  env_var              = var.cloud_run_env_var
+  project              = var.project
+}

--- a/examples/cloudrun/backend/terraform.tfvars
+++ b/examples/cloudrun/backend/terraform.tfvars
@@ -1,0 +1,11 @@
+cloud_run_service_name       = "omegatrade-backend"
+backend_container_image_path = "gcr.io/[PROJECT_NAME]/[APP]:[TAG]"
+cloud_run_region             = "us-west1"
+cloud_run_env_var = {
+  "INSTANCE"   = "[ENTER-SPANNER-INSTANCE-NAME]",
+  "DATABASE"   = "[ENTER-SPANNER-DATABASE-NAME]",
+  "EXPIRE_IN"  = "2d",
+  "JWT_SECRET" = "w54p3Y?4dj%8Xqa2jjVC84narhe5Pk",
+  "PROJECTID"  = "[ENTER-GCP-PROJECT-ID]"
+}
+project = "[ENTER-GCP-PROJECT-ID]"

--- a/examples/cloudrun/backend/variables.tf
+++ b/examples/cloudrun/backend/variables.tf
@@ -1,0 +1,25 @@
+variable "cloud_run_service_name" {
+  type        = string
+  description = "Name of Google Cloud Run Service that being created."
+}
+
+variable "backend_container_image_path" {
+  type        = string
+  description = "Container Path of an application." // if using gcr, must be something: gcr.io/[PROJECT_NAME]/[APP]
+}
+
+variable "cloud_run_region" {
+  type        = string
+  description = "Region in which Google Cloud Run service would be deployed."
+}
+
+variable "cloud_run_env_var" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables to inject into the service instance."
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}

--- a/examples/cloudrun/frontend/main.tf
+++ b/examples/cloudrun/frontend/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+provider "google" {
+  version = "3.51.0" # see https://github.com/terraform-providers/terraform-provider-google/releases
+  project = var.project
+}
+
+resource "random_string" "launch_id" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  suffix = format("%s-%s", "tf", random_string.launch_id.result)
+}
+
+module "cloud_run_frontend" {
+  source               = "../../../modules/cloudrun"
+  suffix               = local.suffix
+  service_name         = "${var.cloud_run_service_name}-frontend"
+  container_image_path = var.backend_container_image_path
+  region               = var.cloud_run_region
+  project              = var.project
+}

--- a/examples/cloudrun/frontend/terraform.tfvars
+++ b/examples/cloudrun/frontend/terraform.tfvars
@@ -1,0 +1,4 @@
+cloud_run_service_name       = "omegatrade-frontend"
+backend_container_image_path = "gcr.io/[PROJECT_NAME]/[APP]:[TAG]"
+cloud_run_region             = "us-west1"
+project                      = "[ENTER-GCP-PROJECT-ID]"

--- a/examples/cloudrun/frontend/variables.tf
+++ b/examples/cloudrun/frontend/variables.tf
@@ -1,0 +1,25 @@
+variable "cloud_run_service_name" {
+  type        = string
+  description = "Name of Google Cloud Run Service that being created."
+}
+
+variable "backend_container_image_path" {
+  type        = string
+  description = "Container Path of an application." // if using gcr, must be something: gcr.io/[PROJECT_NAME]/[APP]
+}
+
+variable "cloud_run_region" {
+  type        = string
+  description = "Region in which Google Cloud Run service would be deployed."
+}
+
+variable "cloud_run_env_var" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables to inject into the service instance."
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}

--- a/examples/gce/main.tf
+++ b/examples/gce/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+provider "google" {
+  version = "3.51.0" # see https://github.com/terraform-providers/terraform-provider-google/releases
+  project = var.project
+}
+
+resource "random_string" "launch_id" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  suffix = format("%s-%s", "tf", random_string.launch_id.result)
+}
+
+module omegatrade {
+  source           = "../../modules/gce"
+  suffix           = local.suffix
+  region           = var.gce_region
+  zone             = var.gce_zone
+  vpc_network_name = var.vpc_network_name
+  instance_name    = var.gce_instance_name
+  network_tags     = var.gce_network_tags
+  project          = var.project
+}

--- a/examples/gce/terraform.tfvars
+++ b/examples/gce/terraform.tfvars
@@ -1,0 +1,6 @@
+gce_region        = "us-central1"
+gce_zone          = "a"
+vpc_network_name  = "main-vpc"
+gce_instance_name = "spanner-emulator"
+gce_network_tags  = ["http-server", "https-server", "ssh", "emulator-server"]
+project           = "[ENTER-GCP-PROJECT-ID]"

--- a/examples/gce/variables.tf
+++ b/examples/gce/variables.tf
@@ -1,0 +1,32 @@
+## --- REQUIRED PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "gce_region" {
+  type        = string
+  description = "Region where the GCE VM Instance resides. Defaults to the Google provider's region if nothing is specified here. See https://cloud.google.com/compute/docs/regions-zones"
+}
+
+variable "gce_zone" {
+  type        = string
+  description = "The zone that the machine should be created in."
+}
+
+variable "vpc_network_name" {
+  type        = string
+  description = "Virtual Private Cloud in which GCE VM Instance would be created. If you have custom VPC network, supply VPC Network Name."
+}
+
+variable "gce_instance_name" {
+  type        = string
+  description = "A unique name for the GCE resource. Changing this forces a new resource to be created."
+}
+
+variable "gce_network_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of network tags to attach to the instance."
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}

--- a/modules/cloud-spanner/main.tf
+++ b/modules/cloud-spanner/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+locals {
+  instance_id           = format("%s-%s", var.instance_id, var.suffix)
+  instance_display_name = format("%s-%s", var.instance_display_name, var.suffix)
+  display_name          = var.instance_display_name == "" ? local.instance_id : local.instance_display_name
+  dbname                = format("%s-%s", var.dbname, var.suffix)
+}
+
+resource "google_project_service" "compute_api" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "spanner_api" {
+  service            = "spanner.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_spanner_instance" "omega_trade" {
+  name         = local.instance_id
+  config       = var.config
+  display_name = local.display_name
+  num_nodes    = var.num_nodes
+  labels       = var.labels_var
+  project      = var.project
+
+  timeouts {
+    create = var.spanner_instance_timeout
+    update = var.spanner_instance_timeout
+    delete = var.spanner_instance_timeout
+  }
+}
+
+resource "google_spanner_database" "omega_trade_database" {
+  instance            = google_spanner_instance.omega_trade.name
+  name                = local.dbname
+  ddl                 = var.ddl_queries
+  deletion_protection = var.deletion_protection
+
+  timeouts {
+    create = var.spanner_db_timeout
+    update = var.spanner_db_timeout
+    delete = var.spanner_db_timeout
+  }
+}

--- a/modules/cloud-spanner/outputs.tf
+++ b/modules/cloud-spanner/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "Unique id of Google Cloud Spanner Instance."
+  value       = local.instance_id
+}
+
+output "instance_display_name" {
+  description = "Display name of Google Cloud Spanner Instance."
+  value       = local.instance_display_name
+}
+
+output "dbname" {
+  description = "Database name created in Google Cloud Spanner."
+  value       = local.dbname
+}
+
+output "ddl_queries" {
+  description = "DDL being created in Google Cloud Spanner DB"
+  value       = var.ddl_queries
+}
+
+output "labels_var" {
+  description = "Labels of created Google Cloud Spanner Instance."
+  value       = var.labels_var
+}

--- a/modules/cloud-spanner/variables.tf
+++ b/modules/cloud-spanner/variables.tf
@@ -1,0 +1,77 @@
+## --- REQUIRED PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "suffix" {
+  description = "An arbitrary suffix that will be added to the end of the resource name(s). For example: an environment name, a business-case name, a numeric id, etc."
+  type        = string
+  validation {
+    condition     = length(var.suffix) <= 14
+    error_message = "A max of 14 character(s) are allowed."
+  }
+}
+
+variable "instance_id" {
+  type        = string
+  description = "A unique identifier for the instance, which cannot be changed after the instance is created."
+}
+
+variable "dbname" {
+  type        = string
+  description = "A unique identifier for the database, which cannot be changed after the instance is created."
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "config" {
+  type        = string
+  description = "Cloud Spanner Instance config - Regional / multi-region. For allowed configurations, check: https://cloud.google.com/spanner/docs/instances#available-configurations-regional"
+}
+
+variable "num_nodes" {
+  type        = number
+  description = "The number of nodes allocated to this instance."
+}
+
+## --- OPTIONAL PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "instance_display_name" {
+  type        = string
+  default     = ""
+  description = "The descriptive name for this instance as it appears in UIs. Must be unique per project and between 4 and 30 characters in length."
+}
+
+variable "labels_var" {
+  type        = map(string)
+  default     = {}
+  description = "Labels to inject into the spanner instance."
+}
+
+variable "ddl_queries" {
+  type = list(string)
+  default = [
+    "CREATE TABLE users ( userId STRING(36) NOT NULL, businessEmail STRING(50), fullName STRING(36), password STRING(100), photoUrl STRING(250), provider STRING(20),) PRIMARY KEY(userId)",
+    "CREATE TABLE companies (companyId STRING(36) NOT NULL, companyName STRING(30), companyShortCode STRING(15), created_at TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true), ) PRIMARY KEY(companyId)",
+    "CREATE TABLE companyStocks (companyStockId STRING(36) NOT NULL, companyId STRING(36) NOT NULL, companyShortCode STRING(10), exchangeName STRING(50), exchangeMic STRING(50), timezone STRING(50), shares FLOAT64, requestId STRING(15), open FLOAT64, volume FLOAT64, currentValue FLOAT64, date FLOAT64, close FLOAT64, dayHigh FLOAT64, dayLow FLOAT64, adjHigh FLOAT64, adjLow FLOAT64, adjClose FLOAT64, adjOpen FLOAT64, adjVolume FLOAT64, timestamp TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true), ) PRIMARY KEY(companyStockId)",
+    "CREATE TABLE simulations (sId STRING(36) NOT NULL, companyId STRING(36) NOT NULL, status BOOL, createdAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp = true),) PRIMARY KEY(sId)",
+  ]
+  description = "An optional list of DDL statements to run inside the newly created database. Statements can create tables, indexes, etc."
+}
+variable "deletion_protection" {
+  type        = bool
+  default     = false
+  description = "Whether or not to allow Terraform to destroy the instance."
+}
+
+variable "spanner_instance_timeout" {
+  type        = string
+  default     = "10m"
+  description = "How long a Google Spanner Instance creation operation is allowed to take before being considered a failure."
+}
+
+variable "spanner_db_timeout" {
+  type        = string
+  default     = "6m"
+  description = "How long a Google Spanner Instance DB creation operation is allowed to take before being considered a failure."
+}

--- a/modules/cloudrun/main.tf
+++ b/modules/cloudrun/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+locals {
+  service_name        = format("%s-%s", var.service_name, var.suffix)
+  allow_authenticated = var.allow_unauth_access ? 1 : 0
+  members             = var.iam_member == "" ? "allUsers" : var.iam_member
+}
+
+resource "google_project_service" "gcr_api" {
+  service            = "containerregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloud_run_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "compute_api" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_cloud_run_service" "omega_trade" {
+  name     = local.service_name
+  location = var.region
+  project  = var.project
+
+  template {
+    spec {
+      containers {
+        image = var.container_image_path
+        ports {
+          container_port = var.container_port
+        }
+        dynamic "env" {
+          for_each = var.env_var
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = var.latest_revision
+  }
+
+  timeouts {
+    create = var.cloud_run_timeout
+    update = var.cloud_run_timeout
+    delete = var.cloud_run_timeout
+  }
+}
+
+resource google_cloud_run_service_iam_member public_access {
+  count    = local.allow_authenticated
+  service  = google_cloud_run_service.omega_trade.name
+  location = google_cloud_run_service.omega_trade.location
+  project  = google_cloud_run_service.omega_trade.project
+  role     = "roles/run.invoker"
+  member   = local.members
+}

--- a/modules/cloudrun/outputs.tf
+++ b/modules/cloudrun/outputs.tf
@@ -1,0 +1,24 @@
+output "service_name" {
+  description = "Name of Google Cloud Run Service"
+  value       = local.service_name
+}
+
+output "region" {
+  description = "Region in which Cloud Run being deployed"
+  value       = var.region
+}
+
+output "container_image_path" {
+  description = "Application container image path"
+  value       = var.container_image_path
+}
+
+output "env_var" {
+  description = "Environment variables of deployed Google Cloud Run service"
+  value       = var.env_var
+}
+
+output "latest_revision" {
+  description = "Current version of deployed Cloud Run service"
+  value       = var.latest_revision
+}

--- a/modules/cloudrun/variables.tf
+++ b/modules/cloudrun/variables.tf
@@ -1,0 +1,68 @@
+## --- REQUIRED PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "suffix" {
+  description = "An arbitrary suffix that will be added to the end of the resource name(s). For example: an environment name, a business-case name, a numeric id, etc."
+  type        = string
+  validation {
+    condition     = length(var.suffix) <= 14
+    error_message = "A max of 14 character(s) are allowed."
+  }
+}
+
+variable "service_name" {
+  type        = string
+  description = "Name of Google Cloud Run Service that being created."
+}
+
+variable "region" {
+  type        = string
+  description = "Region in which Google Cloud Run service would be deployed."
+}
+
+variable "container_image_path" {
+  type        = string
+  description = "Container Path of an application." // if using gcr, must be something: gcr.io/[PROJECT_NAME]/[APP]
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+## --- OPTIONAL PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "container_port" {
+  type        = number
+  default     = 8080
+  description = "Port on which the container is listening for incoming HTTP requests."
+}
+
+variable "env_var" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables to inject into the service instance."
+}
+
+variable "latest_revision" {
+  type        = bool
+  default     = true
+  description = "LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target."
+}
+
+variable "cloud_run_timeout" {
+  type        = string
+  default     = "20m"
+  description = "How long a Cloud Run operation is allowed to take before being considered a failure."
+}
+
+variable "allow_unauth_access" {
+  type        = bool
+  default     = true
+  description = "Allow non-authenticated access to the service."
+}
+
+variable "iam_member" {
+  type        = string
+  default     = ""
+  description = "Who have access to call Cloud Run service. For any users, need to prepend user:[email.com] and for service account prepent, serviceAccount:[serviceaccount] and for group prepend group:[group-email]"
+}

--- a/modules/gce/main.tf
+++ b/modules/gce/main.tf
@@ -1,0 +1,113 @@
+terraform {
+  required_version = ">= 0.13.1" # see https://releases.hashicorp.com/terraform/
+}
+
+locals {
+  instance_name = format("%s-%s", var.instance_name, var.suffix)
+  region        = var.region != "" ? var.region : data.google_client_config.google_client.region
+  network_tags  = tolist(toset(var.network_tags))
+
+  name_static_vm_ip = format("%s-ext-ip-%s", var.instance_name, var.suffix)
+
+  sa_id = format("%s-sa-%s", var.instance_name, var.suffix)
+
+  firewall_name = format("%s-fw-%s", var.instance_name, var.suffix)
+}
+
+resource "google_project_service" "compute_api" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "networking_api" {
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "omega_trade_sa" {
+  account_id   = local.sa_id
+  display_name = local.sa_id
+
+  timeouts {
+    create = var.sa_timeout
+  }
+}
+
+resource "google_compute_address" "omege_trade_static_ip" {
+  name       = local.name_static_vm_ip
+  region     = local.region
+  depends_on = [google_project_service.networking_api]
+
+  timeouts {
+    create = var.static_ip_timeout
+    delete = var.static_ip_timeout
+  }
+}
+
+resource "google_compute_instance" "omega_trade" {
+  name         = local.instance_name
+  machine_type = var.instance_machine_type
+  zone         = format("%s-%s", local.region, var.zone)
+  tags         = local.network_tags
+  project      = var.project
+
+  boot_disk {
+    initialize_params {
+      size  = var.boot_disk_size
+      type  = var.boot_disk_type
+      image = var.boot_disk_image
+    }
+  }
+  network_interface {
+    network = var.vpc_network_name
+    access_config {
+      nat_ip       = google_compute_address.omege_trade_static_ip.address
+      network_tier = "PREMIUM"
+    }
+  }
+
+  allow_stopping_for_update = var.allow_stopping_for_update
+  lifecycle {
+    ignore_changes = [
+      attached_disk,
+    ]
+  }
+  service_account {
+    email  = google_service_account.omega_trade_sa.email
+    scopes = ["cloud-platform"]
+  }
+  depends_on = [google_project_service.compute_api]
+
+  metadata_startup_script = "${file("${path.module}/script.sh")}"
+
+  timeouts {
+    create = var.vm_instance_timeout
+    update = var.vm_instance_timeout
+    delete = var.vm_instance_timeout
+  }
+}
+
+resource "google_project_iam_member" "spanner_role" {
+  role   = "roles/spanner.viewer"
+  member = "serviceAccount:${google_service_account.omega_trade_sa.email}"
+}
+
+resource "google_compute_firewall" "omega_trade_fw" {
+  name    = local.firewall_name
+  network = var.vpc_network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "9010", "9020"]
+  }
+
+  target_tags = local.network_tags
+
+  timeouts {
+    create = var.firewall_timeout
+    update = var.firewall_timeout
+    delete = var.firewall_timeout
+  }
+}
+
+data "google_client_config" "google_client" {}

--- a/modules/gce/outputs.tf
+++ b/modules/gce/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_name" {
+  value       = local.instance_name
+  description = "Name of GCE VM Instance."
+}
+
+output "id" {
+  value       = google_compute_instance.omega_trade.id
+  description = "An identifier for the resource with format projects/{{project}}/zones/{{zone}}/instances/{{name}}"
+}
+
+output "instance_id" {
+  value       = google_compute_instance.omega_trade.instance_id
+  description = "The server-assigned unique identifier of this instance. Example: 4567719474035761998"
+}
+
+output "self_link" {
+  value       = google_compute_address.omege_trade_static_ip.self_link
+  description = "The URI of the External Static IP resource."
+}
+
+output "email" {
+  value       = google_service_account.omega_trade_sa.email
+  description = "The URI of the Google Service Account resource."
+}
+
+output "sa_id" {
+  value       = local.sa_id
+  description = "Display Name of created Google Service Account"
+}
+
+output "region" {
+  value       = var.region
+  description = "GCP Region in which GCE VM Instance being created"
+}

--- a/modules/gce/script.sh
+++ b/modules/gce/script.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+sudo -i 
+
+VERSION=1.2.0
+wget https://storage.googleapis.com/cloud-spanner-emulator/releases/${VERSION}/cloud-spanner-emulator_linux_amd64-${VERSION}.tar.gz
+tar zxvf cloud-spanner-emulator_linux_amd64-${VERSION}.tar.gz
+chmod u+x gateway_main emulator_main
+./gateway_main --hostname 0.0.0.0 --grpc_port 9010 --http_port 9020 &

--- a/modules/gce/variables.tf
+++ b/modules/gce/variables.tf
@@ -1,0 +1,98 @@
+## --- REQUIRED PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "suffix" {
+  description = "An arbitrary suffix that will be added to the end of the resource name(s). For example: an environment name, a business-case name, a numeric id, etc."
+  type        = string
+  validation {
+    condition     = length(var.suffix) <= 14
+    error_message = "A max of 14 character(s) are allowed."
+  }
+}
+
+variable "instance_name" {
+  type        = string
+  description = "A unique name for the GCE resource. Changing this forces a new resource to be created."
+}
+
+variable "region" {
+  type        = string
+  description = "Region where the GCE VM Instance resides. Defaults to the Google provider's region if nothing is specified here. See https://cloud.google.com/compute/docs/regions-zones"
+}
+
+variable "project" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+variable "zone" {
+  type        = string
+  description = "The zone that the machine should be created in."
+}
+
+## --- OPTIONAL PARAMETERS ------------------------------------------------------------------------------------------------
+
+variable "instance_machine_type" {
+  type        = string
+  default     = "e2-medium"
+  description = "The type of GCE VM instance for each nodes."
+}
+
+variable "network_tags" {
+  type        = list(string)
+  default     = []
+  description = "A list of network tags to attach to the instance."
+}
+
+variable "boot_disk_size" {
+  type        = number
+  default     = 50
+  description = "The size of the boot disk in GigaBytes."
+}
+
+variable "boot_disk_type" {
+  type        = string
+  default     = "pd-standard"
+  description = "The GCE disk type. May be set to \"pd-standard\", \"pd-balanced\" or \"pd-ssd\"."
+}
+
+variable "boot_disk_image" {
+  type        = string
+  default     = "ubuntu-1804-lts"
+  description = "GCE VM Instance Underlying Operating System"
+}
+
+variable "vpc_network_name" {
+  type        = string
+  default     = "default"
+  description = "Virtual Private Cloud in which GCE VM Instance would be created. If you have custom VPC network, supply VPC Network Name."
+}
+
+variable "allow_stopping_for_update" {
+  type        = bool
+  default     = false
+  description = "If true, allows Terraform to stop the instance to update its properties. If you try to update a property that requires stopping the instance without setting this field, the update will fail."
+}
+
+variable "vm_instance_timeout" {
+  type        = string
+  default     = "25m"
+  description = "How long a GCE Instance creation operation is allowed to take before being considered a failure."
+}
+
+variable "static_ip_timeout" {
+  type        = string
+  default     = "5m"
+  description = "How long a Static IP creation operation is allowed to take before being considered a failure."
+}
+
+variable "sa_timeout" {
+  type        = string
+  default     = "10m"
+  description = "How long a Service Account creation operation is allowed to take before being considered a failure."
+}
+
+variable "firewall_timeout" {
+  type        = string
+  default     = "5m"
+  description = "How long a Firewall creation operation is allowed to take before being considered a failure."
+}


### PR DESCRIPTION
### Terraform Templates Code

**About**
Terraform Modules and examples (configuration/values) folder for Google Compute Engine Instance, GCP Spanner and Google Cloud Run.
The module folder contains the respective resource terraform template and the examples folder contains values that are being passed.

**How does it work?**
Upon running terraform apply command terraform will provision respective resource in GCP.
Before applying, you must have to update the **project** in each **terraform.tfvars** of examples/{resource}/ folder, then 
```
terraform init && terraform plan 
terraform apply
```

**Test**
All terraform code are reviewed, tested and working as expected.

_This PR is a part of Cloud Spanner-Solution Blogs._